### PR TITLE
Use correct type for `use_callback` & `use_effect_` for cleanup functions

### DIFF
--- a/redraw/src/redraw.gleam
+++ b/redraw/src/redraw.gleam
@@ -203,6 +203,13 @@ pub fn use_deferred_value(value: a) -> a
 @external(javascript, "react", "useEffect")
 pub fn use_effect(value: fn() -> Nil, dependencies: a) -> Nil
 
+/// Let you synchronize a component with an external system. Allow to return
+/// a cleanup function.
+///
+/// [Documentation](https://react.dev/reference/react/useEffect)
+@external(javascript, "react", "useEffect")
+pub fn use_effect_(value: fn() -> fn() -> Nil, dependencies: a) -> Nil
+
 /// Version of useEffect that fires before the browser repaints the screen.
 ///
 /// [Documentation](https://react.dev/reference/react/useLayoutEffect)

--- a/redraw/src/redraw.gleam
+++ b/redraw/src/redraw.gleam
@@ -176,7 +176,7 @@ pub fn suspense(props: Suspense, children: List(Component)) -> Component
 ///
 /// [Documentation](https://react.dev/reference/react/useCallback)
 @external(javascript, "react", "useCallback")
-pub fn use_callback(fun: function, dependencies: dependencies) -> a
+pub fn use_callback(fun: function, dependencies: dependencies) -> function
 
 /// Let you add a label to a custom Hook in React DevTools.
 ///


### PR DESCRIPTION
`use_callback` was returning wrong type. This PR fixes it.